### PR TITLE
Steffanperry/class name support

### DIFF
--- a/spec/associations_spec.cr
+++ b/spec/associations_spec.cr
@@ -19,7 +19,7 @@ describe Mongo::ORM::Document do
     end
 
     it "handles has_many <=> belongs_to relationships as class" do
-      a = TestModuleAdmin.new
+      a = TestModule::TestModuleAdmin.new
       a.test_posters.should eq [] of TestPoster
       a.save
       post = TestPoster.new
@@ -27,7 +27,7 @@ describe Mongo::ORM::Document do
       post.test_admin = a
       post.save
       post = TestPoster.all.first.not_nil!
-      a = TestModuleAdmin.all.first.not_nil!
+      a = TestModule::TestModuleAdmin.all.first.not_nil!
       post.test_admin.equals?(a).should be_true
       a.test_posters.inspect.should eq [post].inspect
       a.test_posters.first.not_nil!.test_admin.equals?(a).should be_true

--- a/spec/associations_spec.cr
+++ b/spec/associations_spec.cr
@@ -18,6 +18,22 @@ describe Mongo::ORM::Document do
       post.test_admin_id = a._id
     end
 
+    it "handles has_many <=> belongs_to relationships as class" do
+      a = TestModuleAdmin.new
+      a.test_posters.should eq [] of TestPoster
+      a.save
+      post = TestPoster.new
+      post.text = "haha"
+      post.test_admin = a
+      post.save
+      post = TestPoster.all.first.not_nil!
+      a = TestModuleAdmin.all.first.not_nil!
+      post.test_admin.equals?(a).should be_true
+      a.test_posters.inspect.should eq [post].inspect
+      a.test_posters.first.not_nil!.test_admin.equals?(a).should be_true
+      post.test_admin_id = a._id
+    end
+
     it "handles embeds_many relationships" do
       admin = TestAdmin.new
       thing1 = TestInnerThing.new

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -21,6 +21,11 @@ class TestPost < Mongo::ORM::Document
   belongs_to :test_admin
 end
 
+class TestPoster < Mongo::ORM::Document
+  field text : String
+  belongs_to :test_admin, class_name: TestModuleAdmin
+end
+
 class TestInnerThing < Mongo::ORM::EmbeddedDocument
   field name : String
 end
@@ -36,14 +41,29 @@ class TestAdmin < Mongo::ORM::Document
   timestamps
 end
 
+class TestModuleAdmin < Mongo::ORM::Document
+  field first_name : String
+  field last_name : String
+  field age : Int32
+  embeds blog : TestBlog
+  has_many :test_posters
+  embeds_many :test_inner_things
+
+  timestamps
+end
+
 Spec.before_each do
   TestUser.drop
   TestAdmin.drop
   TestPost.drop
+  TestPoster.drop
+  TestModuleAdmin.drop
 end
 
 Spec.after_each do
   TestUser.drop
   TestAdmin.drop
   TestPost.drop
+  TestPoster.drop
+  TestModuleAdmin.drop
 end

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -21,11 +21,6 @@ class TestPost < Mongo::ORM::Document
   belongs_to :test_admin
 end
 
-class TestPoster < Mongo::ORM::Document
-  field text : String
-  belongs_to :test_admin, class_name: TestModuleAdmin
-end
-
 class TestInnerThing < Mongo::ORM::EmbeddedDocument
   field name : String
 end
@@ -41,15 +36,22 @@ class TestAdmin < Mongo::ORM::Document
   timestamps
 end
 
-class TestModuleAdmin < Mongo::ORM::Document
-  field first_name : String
-  field last_name : String
-  field age : Int32
-  embeds blog : TestBlog
-  has_many :test_posters
-  embeds_many :test_inner_things
+class TestPoster < Mongo::ORM::Document
+  field text : String
+  belongs_to :test_admin, class_name: TestModule::TestModuleAdmin
+end
 
-  timestamps
+module TestModule
+  class TestModuleAdmin < Mongo::ORM::Document
+    field first_name : String
+    field last_name : String
+    field age : Int32
+    embeds blog : TestBlog
+    has_many :test_posters
+    embeds_many :test_inner_things
+  
+    timestamps
+  end
 end
 
 Spec.before_each do
@@ -57,7 +59,7 @@ Spec.before_each do
   TestAdmin.drop
   TestPost.drop
   TestPoster.drop
-  TestModuleAdmin.drop
+  TestModule::TestModuleAdmin.drop
 end
 
 Spec.after_each do
@@ -65,5 +67,5 @@ Spec.after_each do
   TestAdmin.drop
   TestPost.drop
   TestPoster.drop
-  TestModuleAdmin.drop
+  TestModule::TestModuleAdmin.drop
 end

--- a/src/mongo_orm/associations.cr
+++ b/src/mongo_orm/associations.cr
@@ -18,6 +18,24 @@ module Mongo::ORM::Associations
     end
   end
 
+  macro belongs_to(model_name, class_name = nil)
+    field {{class_name.id.underscore}}_id : BSON::ObjectId
+
+    # retrieve the parent relationship
+    def {{model_name.id}}
+      if parent = {{class_name.id}}.find {{class_name.id.underscore}}_id
+        parent
+      else
+        {{class_name.id}}.new
+      end
+    end
+
+    # set the parent relationship
+    def {{model_name.id}}=(parent)
+      @{{class_name.id.underscore}}_id = parent._id
+    end
+  end
+
   macro has_many(children_collection)
     def {{children_collection.id}}
       {% children_class = children_collection.id[0...-1].camelcase %}

--- a/src/mongo_orm/associations.cr
+++ b/src/mongo_orm/associations.cr
@@ -1,38 +1,20 @@
 module Mongo::ORM::Associations
   # define getter and setter for parent relationship
-  macro belongs_to(model_name)
-    field {{model_name.id}}_id : BSON::ObjectId
+  macro belongs_to(model_name, class_name=nil)
+    field {{class_name ? class_name.id.underscore : model_name.id}}_id : BSON::ObjectId
 
     # retrieve the parent relationship
     def {{model_name.id}}
-      if parent = {{model_name.id.camelcase}}.find {{model_name.id}}_id
+      if parent = {{class_name ? class_name.id : model_name.id.camelcase}}.find {{class_name ? class_name.id.underscore : model_name.id}}_id
         parent
       else
-        {{model_name.id.camelcase}}.new
+        {{class_name ? class_name.id : model_name.id.camelcase}}.new
       end
     end
 
     # set the parent relationship
     def {{model_name.id}}=(parent)
-      @{{model_name.id}}_id = parent._id
-    end
-  end
-
-  macro belongs_to(model_name, class_name = nil)
-    field {{class_name.id.underscore}}_id : BSON::ObjectId
-
-    # retrieve the parent relationship
-    def {{model_name.id}}
-      if parent = {{class_name.id}}.find {{class_name.id.underscore}}_id
-        parent
-      else
-        {{class_name.id}}.new
-      end
-    end
-
-    # set the parent relationship
-    def {{model_name.id}}=(parent)
-      @{{class_name.id.underscore}}_id = parent._id
+      @{{class_name ? class_name.id.underscore : model_name.id}}_id = parent._id
     end
   end
 

--- a/src/mongo_orm/associations.cr
+++ b/src/mongo_orm/associations.cr
@@ -1,11 +1,11 @@
 module Mongo::ORM::Associations
   # define getter and setter for parent relationship
   macro belongs_to(model_name, class_name=nil)
-    field {{class_name ? class_name.id.underscore : model_name.id}}_id : BSON::ObjectId
+    field {{class_name ? class_name.id.underscore.gsub(/::/,"_") : model_name.id}}_id : BSON::ObjectId
 
     # retrieve the parent relationship
     def {{model_name.id}}
-      if parent = {{class_name ? class_name.id : model_name.id.camelcase}}.find {{class_name ? class_name.id.underscore : model_name.id}}_id
+      if parent = {{class_name ? class_name.id : model_name.id.camelcase}}.find {{class_name ? class_name.id.underscore.gsub(/::/,"_") : model_name.id}}_id
         parent
       else
         {{class_name ? class_name.id : model_name.id.camelcase}}.new
@@ -14,7 +14,7 @@ module Mongo::ORM::Associations
 
     # set the parent relationship
     def {{model_name.id}}=(parent)
-      @{{class_name ? class_name.id.underscore : model_name.id}}_id = parent._id
+      @{{class_name ? class_name.id.underscore.gsub(/::/,"_") : model_name.id}}_id = parent._id
     end
   end
 
@@ -22,7 +22,7 @@ module Mongo::ORM::Associations
     def {{children_collection.id}}
       {% children_class = children_collection.id[0...-1].camelcase %}
       return [] of {{children_class}} unless self._id
-      {{children_class}}.all({"#{self.class.to_s.underscore}_id" => self._id})
+      {{children_class}}.all({"#{self.class.to_s.underscore.gsub(/::/,"_")}_id" => self._id})
     end
   end
 end


### PR DESCRIPTION
Adds ability to declare class name for module support similar to ruby implementation

module Products
  class Thing < Mongo::ORM::Document
    belongs_to :widget
  end
end

class Widget
  has_many things, class_name: Products::Thing
end