### PR TITLE
Make compatible with crystal 0.26.0

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -11,4 +11,5 @@ license: MIT
 dependencies:
   mongo:
     github: sam0x17/mongo.cr
-    branch: master
+    commit: e14488246b5c0d9e5f1a3ca4c257936110044b43 # branch 0.25.1
+

--- a/src/mongo_orm/document.cr
+++ b/src/mongo_orm/document.cr
@@ -66,7 +66,7 @@ class Mongo::ORM::Document
     set_attributes(args.to_h)
   end
 
-  def initialize(args : Hash(Symbol | String, String | JSON::Type))
+  def initialize(args : Hash(Symbol | String, String | JSON::Any))
     set_attributes(args)
   end
 

--- a/src/mongo_orm/embedded_fields.cr
+++ b/src/mongo_orm/embedded_fields.cr
@@ -1,7 +1,7 @@
 require "json"
 
 module Mongo::ORM::EmbeddedFields
-  alias Type = JSON::Type | DB::Any
+  alias Type = JSON::Any | DB::Any
   TIME_FORMAT_REGEX = /\d{4,}-\d{2,}-\d{2,}\s\d{2,}:\d{2,}:\d{2,}/
 
   macro included

--- a/src/mongo_orm/fields.cr
+++ b/src/mongo_orm/fields.cr
@@ -1,7 +1,7 @@
 require "json"
 
 module Mongo::ORM::Fields
-  alias Type = JSON::Type | DB::Any
+  alias Type = JSON::Any | DB::Any
   TIME_FORMAT_REGEX = /\d{4,}-\d{2,}-\d{2,}\s\d{2,}:\d{2,}:\d{2,}/
 
   macro included


### PR DESCRIPTION
Fixes problem with JSON::Type.

Other errors are happening
```
Error in line 1: while requiring "./spec/associations_spec.cr"

in spec/associations_spec.cr:7: instantiating 'TestAdmin#test_posts()'

      a.test_posts.should eq [] of TestPost
        ^~~~~~~~~~

in spec/spec_helper.cr:33: expanding macro

  has_many :test_posts
  ^

in macro 'has_many' /home/andre/Documents/Projects/mongo_orm/src/mongo_orm/associations.cr:21, line 4:

   1.     def test_posts
   2.       
   3.       return [] of TestPost unless self._id
>  4.       TestPost.all({"#{self.class.to_s.underscore.gsub(/::/,"_")}_id" => self._id})
   5.     end
   6.   

instantiating 'TestPost.class#all(Hash(String, BSON::ObjectId | Nil))'
in src/mongo_orm/querying.cr:90: instantiating 'all(Hash(String, BSON::ObjectId | Nil), Int32, Int32, Int32, LibMongoC::QueryFlags, Nil)'

  def all(query = BSON.new, skip = 0, limit = 0, batch_size = 0, flags = LibMongoC::QueryFlags::NONE, prefs = nil)
  ^

in src/mongo_orm/querying.cr:92: instantiating 'Mongo::Cursor#each()'

    collection.find(query, BSON.new, flags, skip, limit, batch_size, prefs).each do |doc|
                                                                            ^~~~

in src/mongo_orm/querying.cr:92: instantiating 'Mongo::Cursor#each()'

    collection.find(query, BSON.new, flags, skip, limit, batch_size, prefs).each do |doc|
                                                                            ^~~~

in src/mongo_orm/querying.cr:93: instantiating 'from_bson(BSON)'

      rows << from_bson(doc) if doc
              ^~~~~~~~~

in macro 'finished' expanded macro: inherited:1, line 3:

   1.       __process_collection
   2.       __process_fields
>  3.       __process_querying
   4.       __process_persistence
   5. 
   6.       def inspect(io)
   7.         sts = [] of String
   8.         sts << " _id: #{self._id.nil? ? "nil" : self._id.inspect}"
   9.         fields.each do |field_name, field_value|
  10.           next if field_name == "_id"
  11.           sts << " #{field_name}: #{field_value.nil? ? "nil" : field_value.inspect}"
  12.         end
  13.         io << "#{self.class} {#{sts.join(",")}}"
  14.       end
  15.     

expanding macro
in macro '__process_querying' expanded macro: extended:1, line 6:

   1.       
   2.       
   3. 
   4.       def self.from_bson(bson : BSON)
   5.         model = TestPost.new
>  6.         model._id = bson["_id"].as(BSON::ObjectId) if bson["_id"]?
   7.         fields = {} of String => Bool
   8.         
   9.         
  10.           fields["text"] = true
  11.           if String.is_a? Mongo::ORM::EmbeddedDocument.class
  12.             model.text = String.from_bson(bson["text"])
  13.           else
  14.             model.text = bson["text"].as(Union(String | Nil))
  15.           end
  16.           
  17.         
  18.           fields["test_admin_id"] = true
  19.           if BSON::ObjectId.is_a? Mongo::ORM::EmbeddedDocument.class
  20.             model.test_admin_id = BSON::ObjectId.from_bson(bson["test_admin_id"])
  21.           else
  22.             model.test_admin_id = bson["test_admin_id"].as(Union(BSON::ObjectId | Nil))
  23.           end
  24.           
  25.         
  26.         
  27.         bson.each_key do |key|
  28.           next if fields.has_key?(key)
  29.           model.set_extended_value(key, bson[key])
  30.         end
  31.         model
  32.       end
  33. 
  34.       def to_bson
  35.         bson = BSON.new
  36.         bson["_id"] = self._id  if self._id != nil
  37.         
  38.           bson["text"] = text.as(Union(String | Nil))
  39.         
  40.           bson["test_admin_id"] = test_admin_id.as(Union(BSON::ObjectId | Nil))
  41.         
  42.         
  43.         
  44.         extended_bson.each_key do |key|
  45.           bson[key] = extended_bson[key] unless bson.has_key?(key)
  46.         end
  47.         bson
  48.       end
  49.     

instantiating 'BSON#[]?(String)'
in lib/mongo/src/bson.cr:123: instantiating 'fetch(String)'

    fetch(key) { nil }
    ^~~~~

in lib/mongo/src/bson.cr:116: instantiating 'BSON::Value#value()'

      Value.new(value).value
                       ^~~~~

in lib/mongo/src/bson/value.cr:42: undefined constant Time::Kind::Utc

        Time.new(spec, Time::Kind::Utc)
                       ^~~~~~~~~~~~~~~

```